### PR TITLE
Add some logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [org.clojure/tools.cli "0.2.2"]
                  [org.clojure/tools.logging "0.2.3"]
                  [factual/clj-helix "0.1.0"]
-                 [io/netty/netty "4.0.0.Alpha8"]
+                 [io.netty/netty "4.0.0.Alpha8"]
                  [com.taoensso/nippy "2.1.0"]
                  [com.google.protobuf/protobuf-java "2.5.0"]
                  [org.clojure/data.codec "0.1.0"]

--- a/src/skuld/bin.clj
+++ b/src/skuld/bin.clj
@@ -1,6 +1,7 @@
 (ns skuld.bin
   (:use [clj-helix.logging :only [mute]]
-        [clojure.tools.cli :only [cli]])
+        [clojure.tools.cli :only [cli]]
+        clojure.tools.logging)
   (:require [skuld.admin :as admin]
             [skuld.node :as node]
             [skuld.flake :as flake])
@@ -67,8 +68,8 @@
                       (Thread. (bound-fn []
                                  (node/shutdown! controller))))
 
-    (println "Controller started.")
-    (prn controller)
+    (info "Controller started.")
+    (debug controller)
     @(promise)))
 
 (defn start [& args]
@@ -80,7 +81,7 @@
                       (Thread. (bound-fn []
                                  (node/shutdown! node))))
 
-    (prn :started node)
+    (info :started node)
     @(promise)))
 
 (defn -main

--- a/src/skuld/logging.clj
+++ b/src/skuld/logging.clj
@@ -1,0 +1,101 @@
+(ns skuld.logging
+  "Configures log4j to log to a file. It's a trap!"
+  ; With thanks to arohner
+  (:import (org.apache.log4j
+             Logger
+             BasicConfigurator
+             PatternLayout
+             Level
+             ConsoleAppender
+             FileAppender
+             SimpleLayout
+             RollingFileAppender)
+           (org.apache.log4j.spi RootLogger))
+  (:import org.apache.commons.logging.LogFactory))
+
+(def levels {:trace org.apache.log4j.Level/TRACE
+             :debug org.apache.log4j.Level/DEBUG
+             :info  org.apache.log4j.Level/INFO
+             :warn  org.apache.log4j.Level/WARN
+             :error org.apache.log4j.Level/ERROR
+             :fatal org.apache.log4j.Level/FATAL})
+
+(defn set-level
+  "Set the level for the given logger, by string name. Use:
+  (set-level \"skuld.node\", :debug)"
+  ([level]
+    (. (Logger/getRootLogger) (setLevel (levels level))))
+  ([logger level]
+    (. (Logger/getLogger logger) (setLevel (levels level)))))
+
+(defmacro with-level
+  "Sets logging for the evaluation of body to the desired level."
+  [level loggers & body]
+  (let [[logger & more] (flatten [loggers])]
+    (if logger
+      `(let [l4j-logger# (Logger/getLogger ~logger)
+             old-level# (.getLevel l4j-logger#)]
+         (try
+           (set-level ~logger ~level)
+           (with-level ~level ~more ~@body)
+           (finally
+             (.setLevel l4j-logger# old-level#))))
+      `(do ~@body))))
+
+(defmacro suppress
+  "Turns off logging for the evaluation of body."
+  [loggers & body]
+  (with-level :fatal loggers body))
+
+(def skuld-layout
+  "A nice format for log lines."
+  (PatternLayout. "%p [%d] %t - %c - %m%n%xEx%n"))
+
+(defn init
+  "Initialize log4j. You will probably call this from the config file. You can
+  call init more than once; its changes are destructive. Options:
+
+  :file   The file to log to. If omitted, logs to console only."
+  [& { :keys [file] }]
+  ; Reset loggers
+  (doto (Logger/getRootLogger)
+    (.removeAllAppenders)
+    (.addAppender (ConsoleAppender. skuld-layout)))
+
+  (comment
+  (when file
+    (let [rolling-policy (doto (TimeBasedTriggeringPolicy.)
+                           (.setActiveFileName file)
+                           (.setFileNamePattern
+                             (str file ".%d{yyyy-MM-dd}.gz"))
+                           (.activateOptions))
+          log-appender (doto (RollingFileAppender.)
+                         (.setRollingPolicy rolling-policy)
+                         (.setLayout skuld-layout)
+                         (.activateOptions))]
+      (.addAppender (Logger/getRootLogger) log-appender)))
+    )
+
+  ; Set levels.
+  (set-level :info)
+
+  (set-level "skuld.node" :debug)
+
+; Not sure where he intended this to go....
+(defn- add-file-appender [loggername filename]
+  (.addAppender (Logger/getLogger loggername)
+    (doto (FileAppender.)
+      (.setLayout skuld-layout))))
+
+  (comment
+(defn nice-syntax-error
+  "Rewrites clojure.lang.LispReader$ReaderException to have error messages that
+  might actually help someone."
+  ([e] (nice-syntax-error e "(no file)"))
+  ([e file]
+    ; Lord help me.
+    (let [line (wall.hack/field (class e) :line e)
+          msg (.getMessage (or (.getCause e) e))]
+      (RuntimeException. (str "Syntax error (" file ":" line ") " msg))))))
+
+  )

--- a/src/skuld/logging.clj
+++ b/src/skuld/logging.clj
@@ -3,15 +3,7 @@
   ; With thanks to arohner
   (:import (org.apache.log4j
              Logger
-             BasicConfigurator
-             PatternLayout
-             Level
-             ConsoleAppender
-             FileAppender
-             SimpleLayout
-             RollingFileAppender)
-           (org.apache.log4j.spi RootLogger))
-  (:import org.apache.commons.logging.LogFactory))
+             Level)))
 
 (def levels {:trace org.apache.log4j.Level/TRACE
              :debug org.apache.log4j.Level/DEBUG
@@ -46,56 +38,3 @@
   "Turns off logging for the evaluation of body."
   [loggers & body]
   (with-level :fatal loggers body))
-
-(def skuld-layout
-  "A nice format for log lines."
-  (PatternLayout. "%p [%d] %t - %c - %m%n%xEx%n"))
-
-(defn init
-  "Initialize log4j. You will probably call this from the config file. You can
-  call init more than once; its changes are destructive. Options:
-
-  :file   The file to log to. If omitted, logs to console only."
-  [& { :keys [file] }]
-  ; Reset loggers
-  (doto (Logger/getRootLogger)
-    (.removeAllAppenders)
-    (.addAppender (ConsoleAppender. skuld-layout)))
-
-  (comment
-  (when file
-    (let [rolling-policy (doto (TimeBasedTriggeringPolicy.)
-                           (.setActiveFileName file)
-                           (.setFileNamePattern
-                             (str file ".%d{yyyy-MM-dd}.gz"))
-                           (.activateOptions))
-          log-appender (doto (RollingFileAppender.)
-                         (.setRollingPolicy rolling-policy)
-                         (.setLayout skuld-layout)
-                         (.activateOptions))]
-      (.addAppender (Logger/getRootLogger) log-appender)))
-    )
-
-  ; Set levels.
-  (set-level :info)
-
-  (set-level "skuld.node" :debug)
-
-; Not sure where he intended this to go....
-(defn- add-file-appender [loggername filename]
-  (.addAppender (Logger/getLogger loggername)
-    (doto (FileAppender.)
-      (.setLayout skuld-layout))))
-
-  (comment
-(defn nice-syntax-error
-  "Rewrites clojure.lang.LispReader$ReaderException to have error messages that
-  might actually help someone."
-  ([e] (nice-syntax-error e "(no file)"))
-  ([e file]
-    ; Lord help me.
-    (let [line (wall.hack/field (class e) :line e)
-          msg (.getMessage (or (.getCause e) e))]
-      (RuntimeException. (str "Syntax error (" file ":" line ") " msg))))))
-
-  )

--- a/src/skuld/net.clj
+++ b/src/skuld/net.clj
@@ -74,7 +74,7 @@
                   i  (InputStreamReader. is)
                   r  (PushbackReader. i)]
         (binding [*read-eval* false]
-;          (prn "Got" (.toString buffer (Charset/forName "UTF-8")))
+;          (debug "Got" (.toString buffer (Charset/forName "UTF-8")))
           (edn/read r))))))
 
 (defn nippy-codec []

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -388,7 +388,7 @@
                                          :router @routerp
                                          :net net}))))
                 (catch Throwable t
-                  (locking *out* (prn t "bringing" part "online"))
+                  (locking *out* (debug t "bringing" part "online"))
                   (throw t))))
 
     (:offline :DROPPED [part m c]

--- a/test/skuld/claim_test.clj
+++ b/test/skuld/claim_test.clj
@@ -1,10 +1,10 @@
 (ns skuld.claim-test
-  (:use [clj-helix.logging :only [mute]]
-        clojure.tools.logging
+  (:use clojure.tools.logging
         clojure.test
         skuld.util
         skuld.node
         skuld.node-test)
+
   (:require [skuld.client  :as client]
             [skuld.admin   :as admin]
             [skuld.vnode   :as vnode]

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -13,6 +13,7 @@
             [skuld.task    :as task]
             [skuld.aae     :as aae]
             [skuld.politics :as politics]
+            [skuld.logging :as logging]
             [clojure.set   :as set]
             clj-helix.admin)
   (:import com.aphyr.skuld.Bytes))
@@ -20,7 +21,8 @@
 (flake/init!)
 
 (def admin
-  (admin/admin {:partitions 2 :replicas 3}))
+  (logging/with-level :warn ["org.apache.zookeeper" "org.apache.helix" "org.I0Itec.zkclient"]
+    (admin/admin {:partitions 2 :replicas 3})))
 
 (def ^:dynamic *client* nil)
 (def ^:dynamic *nodes* nil)
@@ -74,8 +76,8 @@
                         (remove partition-available?))]
       (when-not (empty? unelected)
         (locking *out*
-          (prn (count unelected) "unelected partitions"))
-;          (prn (map (partial map (juxt (comp :port vnode/net-id)
+          (debug (count unelected) "unelected partitions"))
+;          (debug (map (partial map (juxt (comp :port vnode/net-id)
 ;                                       :partition
 ;                                       vnode/state))
 ;                    unelected)))


### PR DESCRIPTION
This replaces `prn` calls with calls to a real logger.

It also silences the initialization log messages from zookeeper in tests.
