### PR TITLE
Add slf4j

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,14 @@
   :java-source-paths ["src/skuld/"]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :exclusions [[log4j]
+               [org.slf4j/slf4j-log4j12]]
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.cli "0.2.2"]
                  [org.clojure/tools.logging "0.2.3"]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]
                  [factual/clj-helix "0.1.0"]
                  [io.netty/netty "4.0.0.Alpha8"]
                  [com.taoensso/nippy "2.1.0"]

--- a/src/skuld/logging.clj
+++ b/src/skuld/logging.clj
@@ -18,6 +18,18 @@
       level
       (Level/toLevel (name level))))
 
+(def root-logger-name
+  org.slf4j.Logger/ROOT_LOGGER_NAME)
+
+(def root-logger
+  (LoggerFactory/getLogger root-logger-name))
+
+(defn get-logger
+  [logger-name]
+  (prn :get-logger logger-name)
+  (org.slf4j.LoggerFactory/getLogger
+    (or logger-name root-logger-name)))
+
 (def root-logger-context
   (.getLoggerContext root-logger))
 
@@ -29,17 +41,7 @@
   []
   (map (fn [logger] (.getName logger)) (all-loggers)))
 
-(def root-logger-name
-  org.slf4j.Logger/ROOT_LOGGER_NAME)
 
-(defn get-logger
-  [logger-name]
-  (prn :get-logger logger-name)
-  (org.slf4j.LoggerFactory/getLogger
-    (or logger-name root-logger-name)))
-
-(def root-logger
-  (LoggerFactory/getLogger root-logger-name))
 
 
 (defn set-level

--- a/src/skuld/logging.clj
+++ b/src/skuld/logging.clj
@@ -1,40 +1,98 @@
 (ns skuld.logging
-  "Configures log4j to log to a file. It's a trap!"
-  ; With thanks to arohner
-  (:import (org.apache.log4j
-             Logger
-             Level)))
+  "Configures logger"
+  (:import (ch.qos.logback.classic
+             Level
+             Logger)
+           (org.slf4j
+             LoggerFactory)
+           (ch.qos.logback.classic.jul
+             LevelChangePropagator)
+           (ch.qos.logback.core
+             ConsoleAppender)))
 
-(def levels {:trace org.apache.log4j.Level/TRACE
-             :debug org.apache.log4j.Level/DEBUG
-             :info  org.apache.log4j.Level/INFO
-             :warn  org.apache.log4j.Level/WARN
-             :error org.apache.log4j.Level/ERROR
-             :fatal org.apache.log4j.Level/FATAL})
+
+(defn level-for
+  "Get the level for a given symbol"
+  [level]
+    (if (instance? Level level)
+      level
+      (Level/toLevel (name level))))
+
+(def root-logger-context
+  (.getLoggerContext root-logger))
+
+(defn all-loggers
+  []
+  (.getLoggerList root-logger-context))
+
+(defn all-logger-names
+  []
+  (map (fn [logger] (.getName logger)) (all-loggers)))
+
+(def root-logger-name
+  org.slf4j.Logger/ROOT_LOGGER_NAME)
+
+(defn get-logger
+  [logger-name]
+  (prn :get-logger logger-name)
+  (org.slf4j.LoggerFactory/getLogger
+    (or logger-name root-logger-name)))
+
+(def root-logger
+  (LoggerFactory/getLogger root-logger-name))
+
 
 (defn set-level
   "Set the level for the given logger, by string name. Use:
   (set-level \"skuld.node\", :debug)"
   ([level]
-    (. (Logger/getRootLogger) (setLevel (levels level))))
+    (set-level nil level))
   ([logger level]
-    (. (Logger/getLogger logger) (setLevel (levels level)))))
+    (prn :set-level logger level)
+    (.setLevel (get-logger logger) (level-for level))))
 
 (defmacro with-level
   "Sets logging for the evaluation of body to the desired level."
-  [level loggers & body]
-  (let [[logger & more] (flatten [loggers])]
-    (if logger
-      `(let [l4j-logger# (Logger/getLogger ~logger)
-             old-level# (.getLevel l4j-logger#)]
+  [level logger-names & body]
+  (let [[logger-name & more] (flatten [logger-names])]
+    (prn :with-level level logger-names)
+    (if logger-name
+      `(let [logger# (get-logger ~logger-name)
+             old-level# (.getLevel logger#)]
          (try
-           (set-level ~logger ~level)
+           (.setLevel logger# (level-for ~level))
            (with-level ~level ~more ~@body)
            (finally
-             (.setLevel l4j-logger# old-level#))))
+             (.setLevel logger# old-level#))))
       `(do ~@body))))
+
+(defmacro mute
+  "Turns off logging for all loggers the evaluation of body."
+  [body]
+  (with-level :off (all-logger-names) body))
 
 (defmacro suppress
   "Turns off logging for the evaluation of body."
   [loggers & body]
-  (with-level :fatal loggers body))
+  (with-level :off loggers body))
+
+(defn init
+  []
+  (let [context (.getLoggerContext root-logger)]
+    (doto context
+      .reset
+      (prn :context)
+      (.addListener
+        (doto (LevelChangePropagator.)
+          (.setContext context)
+          (.setResetJUL true))))
+    (.addAppender root-logger
+      (doto (ConsoleAppender.)
+        (.setName "console-appender")
+        (.setContext context)
+        (prn :appender)
+        (.start))
+      )
+    (set-level :info)))
+
+(init)

--- a/src/skuld/logging.clj
+++ b/src/skuld/logging.clj
@@ -55,10 +55,10 @@
   "Sets logging for the evaluation of body to the desired level."
   [level-name logger-names & body]
   `(let [loggers# (map get-logger (flatten [~logger-names]))
-         levels#  (doall (map #(.getLevel %) loggers#))
+         levels#  (doall (map #(.getLevel ^Logger %) loggers#))
          level#   (level-for ~level-name)]
      (try
-       (doseq [l# loggers#] (.setLevel l# level#))
+       (doseq [^Logger l# loggers#] (.setLevel l# level#))
        (do ~@body)
        (finally
          (dorun (map (fn [^Logger logger#

--- a/src/skuld/logging.clj
+++ b/src/skuld/logging.clj
@@ -3,7 +3,8 @@
   (:import (ch.qos.logback.classic
              Level
              Logger
-             LoggerContext)
+             LoggerContext
+             PatternLayout)
            (org.slf4j
              LoggerFactory)
            (ch.qos.logback.classic.jul
@@ -27,7 +28,6 @@
 
 (defn ^Logger get-logger
   [^String logger-name]
-  (prn :get-logger logger-name)
   (LoggerFactory/getLogger
     (or logger-name root-logger-name)))
 
@@ -48,18 +48,18 @@
   ([level]
     (set-level nil level))
   ([^Logger logger level]
-    (prn :set-level logger level)
     (.setLevel (get-logger logger) (level-for level))))
 
 (defmacro with-level
   "Sets logging for the evaluation of body to the desired level."
   [level-name logger-names & body]
   `(let [level# (level-for ~level-name)
-         loggers-and-levels# ((->> [~logger-names]
+         root-logger-level# (.getLevel root-logger)
+         loggers-and-levels# (doall
+                               (->> [~logger-names]
                                 flatten
                                 (map get-logger)
-                                (map #(list % (.getLevel ^Logger %)))
-                                (remove (comp nil? second))))]
+                                (map #(list % (or (.getLevel ^Logger %) root-logger-level#)))))]
      (try
        (doseq [[^Logger logger# orig-level#] loggers-and-levels#]
          (.setLevel logger# level#))
@@ -71,28 +71,32 @@
 (defmacro mute
   "Turns off logging for all loggers the evaluation of body."
   [& body]
-  (with-level :off (all-logger-names) ~@body))
+  `(with-level :off (all-logger-names) ~@body))
 
 (defmacro suppress
   "Turns off logging for the evaluation of body."
   [loggers & body]
-  (with-level :off loggers ~@body))
+  `(with-level :off ~loggers ~@body))
 
 (defn init
   []
-  (let [context (.getLoggerContext root-logger)]
-    (doto context
-      .reset
-      (.addListener
-        (doto (LevelChangePropagator.)
-          (.setContext context)
-          (.setResetJUL true))))
-    (.addAppender root-logger
-      (doto (ConsoleAppender.)
-        (.setName "console-appender")
-        (.setContext context)
-        (.start))
-      )
-    (set-level :info)))
+  (doto root-logger-context
+    .reset
+    (.addListener
+      (doto (LevelChangePropagator.)
+        (.setContext root-logger-context)
+        (.setResetJUL true))))
+  (.addAppender root-logger
+    (doto (ConsoleAppender.)
+      (.setName "console-appender")
+      (.setContext root-logger-context)
+      (.setLayout
+        (doto (PatternLayout.)
+          (.setContext root-logger-context)
+          (.setPattern "%date{YYYY-MM-dd'T'HH:mm:ss.SSS} %-5p %c: %m%n%xEx")
+          (.start)))
+      (.start))
+    )
+  (set-level :info))
 
 (init)

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -1,6 +1,5 @@
 (ns skuld.node-test
-  (:use [clj-helix.logging :only [mute]]
-        clojure.tools.logging
+  (:use clojure.tools.logging
         clojure.test
         skuld.zk-test
         skuld.util
@@ -95,9 +94,9 @@
 (defn once
   [f]
   (with-zk [zk]
-    (mute (ensure-cluster! (admin zk)))
+    (logging/mute (ensure-cluster! (admin zk)))
     (prn :starting-nodes)
-    (mute (binding [*zk*    zk
+    (logging/mute (binding [*zk*    zk
                     *nodes* (start-nodes! zk)]
             (try
               (prn :starting-client)


### PR DESCRIPTION
Replaces all of the other loggers with a logback-based slf4j logger.

Adds logging to stdout.

We will need to discuss what sort of log tuning should happen and where — It's likely we should set some defaults for the zookeeper stuff in `skuld.logging/init`.

I'm not sure if this is ready to be merged yet, but it's making progress.
