### PR TITLE
add basic http test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,8 @@
   :jvm-opts ^:replace ["-server"]
   :profiles {:dev {:dependencies [[criterium "0.4.1"]
                                   [com.google.guava/guava "14.0.1"]
-                                  [org.apache.curator/curator-test "2.0.1-incubating"]]}}
+                                  [org.apache.curator/curator-test "2.0.1-incubating"]
+                                  [clj-http "0.7.7"]]}}
   :test-selectors {:default (fn [x] (not (or (:integration x)
                                              (:time x)
                                              (:bench x))))

--- a/src/skuld/http.clj
+++ b/src/skuld/http.clj
@@ -19,7 +19,8 @@
   [node]
   (fn [req]
     (condp route-matches req
-      "/list_tasks" (http-response 200 (node/list-tasks node {})))))
+      "/list_tasks" (http-response 200 (pr-str (node/list-tasks node {})))
+      (http-response 404 "Not Found"))))
 
 (defn service
   "Given a node and port, constructs a Jetty instance."

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -4,16 +4,17 @@
         skuld.zk-test
         skuld.util
         skuld.node)
-  (:require [skuld.client  :as client]
-            [skuld.admin   :as admin]
-            [skuld.vnode   :as vnode]
-            [skuld.curator :as curator]
-            [skuld.net     :as net]
-            [skuld.task    :as task]
-            [skuld.aae     :as aae]
-            [skuld.politics :as politics]
-            [skuld.logging :as logging]
-            [clojure.set   :as set]
+  (:require [skuld.client    :as client]
+            [skuld.admin     :as admin]
+            [skuld.vnode     :as vnode]
+            [skuld.curator   :as curator]
+            [skuld.net       :as net]
+            [skuld.task      :as task]
+            [skuld.aae       :as aae]
+            [skuld.politics  :as politics]
+            [skuld.logging   :as logging]
+            [clojure.set     :as set]
+            [clj-http.client :as http]
             skuld.http
             skuld.flake-test
             clj-helix.admin)
@@ -205,3 +206,12 @@
       (is (= n (count tasks)))
       (is (= (sort (map :id tasks)) (map :id tasks)))
       (is (every? :data tasks)))))
+
+(deftest list-tasks-http-test
+  (let [n 10]
+    (dotimes [i n]
+      (client/enqueue! *client* {:w 3} {:data "sup"}))
+
+    ; TODO: real tests
+    (let [resp (http/get "http://127.0.0.1:13100/list_tasks")]
+      (is (= 200 (:status resp))))))


### PR DESCRIPTION
In order to prevent ring/jetty from throwing a 500, `pr-str` is called over the
result of calling `node/list-tasks`. Seemingly this is necessary to prevent
errors when serving the request. However there might be a better way of
handling this and simply serving up bytes directly?

This patch also adds a 404 response, when no route matches.
