### PR TITLE
Log what peer failed clock-sync

### DIFF
--- a/src/skuld/clock_sync.clj
+++ b/src/skuld/clock_sync.clj
@@ -33,9 +33,12 @@
                  (mapcat #(route/instances router :skuld % :peer))
                  set
                  (map (fn [peer]
-                        (net/send! net peer {:type :clock-sync
-                                             :node (select-keys net [:host :port])
-                                             :time (flake/linear-time)})))
+                        (try
+                          (net/send! net peer {:type :clock-sync
+                                               :node (select-keys net [:host :port])
+                                               :time (flake/linear-time)})
+                          (catch Throwable t
+                            (warn t "clock-sync to " peer)))))
                  dorun)
             (catch Throwable t
               (warn t "clock-sync caught")))

--- a/src/skuld/clock_sync.clj
+++ b/src/skuld/clock_sync.clj
@@ -37,6 +37,8 @@
                           (net/send! net peer {:type :clock-sync
                                                :node (select-keys net [:host :port])
                                                :time (flake/linear-time)})
+                          (catch io.netty.channel.ChannelException ex
+                            (warnf "clock-sync to {}: {}" peer ex))
                           (catch Throwable t
                             (warn t "clock-sync to " peer)))))
                  dorun)

--- a/test/skuld/zk_test.clj
+++ b/test/skuld/zk_test.clj
@@ -13,7 +13,7 @@
     ...)"
   [[connect-string] & body]
   `(logging/suppress
-     ["org.apache.zookeeper" "org.apache.helix" "org.apache.curator" "org.I0Itec.zkclient"]
+     ["org.apache.zookeeper" "org.apache.helix" "org.apache.curator" "org.I0Itec.zkclient" "org.apache.zookeeper.server.SessionTrackerImpl"]
      (let [zk#             (TestingServer.)
            ~connect-string (.getConnectString zk#)]
        (try


### PR DESCRIPTION
When a peer isn't running to perform a clock-sync, we should log which one it
was.
