### PR TITLE
Improve logging to aid in debugging transient issues

### DIFF
--- a/src/skuld/net.clj
+++ b/src/skuld/net.clj
@@ -14,7 +14,7 @@
                     DataInputStream
                     InputStreamReader
                     PushbackReader)
-           (java.net InetSocketAddress)
+           (java.net InetSocketAddress ConnectException)
            (java.nio.charset Charset)
            (java.util List)
            (java.util.concurrent TimeUnit
@@ -184,7 +184,10 @@
             (catch Throwable t
               (warn t "node handler caught")))))
       (exceptionCaught [^ChannelHandlerContext ctx ^Throwable cause]
-        (warn cause "client handle caught exception" node)))))
+        (let [peer (.. ctx channel (attr peer-attr) get)]
+          (condp instance? cause
+            ConnectException (warn "client handle caught exception with" peer cause)
+                             (warn cause "client handle caught exception with" peer)))))))
 
 (defn client
   [node]
@@ -237,15 +240,15 @@
 
   (let [^Bootstrap bootstrap (:bootstrap @(:client node))]
     (locking bootstrap
-      (let [ch (.. bootstrap
+      (let [cf (.. bootstrap
                    (remoteAddress ^String (:host peer) (int (:port peer)))
-                   (connect)
-                   (sync)
-                   (channel))]
+                   (connect))
+            ch (.channel cf)]
         ; Store the peer ID in the channel's attributes for later.
         (.. ch
             (attr peer-attr)
             (set (string-id peer)))
+        (.sync cf)
         ch))))
 
 (defn ^Channel conn

--- a/src/skuld/net.clj
+++ b/src/skuld/net.clj
@@ -186,7 +186,7 @@
       (exceptionCaught [^ChannelHandlerContext ctx ^Throwable cause]
         (let [peer (.. ctx channel (attr peer-attr) get)]
           (condp instance? cause
-            ConnectException (warn "client handle caught exception with" peer cause)
+            ConnectException (warnf "client handle caught exception with {}: {}" peer (.getMessage cause))
                              (warn cause "client handle caught exception with" peer)))))))
 
 (defn client

--- a/src/skuld/net.clj
+++ b/src/skuld/net.clj
@@ -182,7 +182,9 @@
           (try
             (handle-response! requests id message)
             (catch Throwable t
-              (warn t "node handler caught"))))))))
+              (warn t "node handler caught")))))
+      (exceptionCaught [^ChannelHandlerContext ctx ^Throwable cause]
+        (warn cause "client handle caught exception" node)))))
 
 (defn client
   [node]

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -327,6 +327,7 @@
           ; Done
           {}
           (do
+            (trace-log node "claim: asking" peer "for a claim")
             (let [[response] (net/sync-req! (:net node) [peer] {}
                                             (assoc msg :type :claim-local))]
               (if (:task response)

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -301,7 +301,7 @@
                        (trace-log node "claim-local: claim from" (vnode/full-id vnode) "returned task:" ta)
                        ta)
                      (catch Throwable t
-                       (warn t "caught while claiming" id "from vnode")
+                       (warn t "caught while claiming" id "from vnode" (vnode/full-id vnode))
                        :retry)))))]
 
     (if (not= :retry task)

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -28,10 +28,15 @@
 (in-ns 'skuld.node)
 
 ;; Logging
+(defn trace-log-prefix
+  "Prefix for trace log messages"
+  [node]
+  (format "%s:%d:" (:host node) (:port node)))
+
 (defmacro trace-log
   "Log a message with context"
   [node & args]
-  `(let [node-prefix# (format "%s:%d:" (:host ~node) (:port ~node))]
+  `(let [node-prefix# (trace-log-prefix ~node)]
      (info node-prefix# ~@args)))
 
 ;;
@@ -301,7 +306,7 @@
                        (trace-log node "claim-local: claim from" (vnode/full-id vnode) "returned task:" ta)
                        ta)
                      (catch Throwable t
-                       (warn t "caught while claiming" id "from vnode" (vnode/full-id vnode))
+                       (warn t (trace-log-prefix node) "caught while claiming" id "from vnode" (vnode/full-id vnode))
                        :retry)))))]
 
     (if (not= :retry task)

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -448,7 +448,7 @@
     (:offline :peer [part m c]
               (try
                 (locking vnodes
-                  (info (:port net) part "coming online")
+                  (trace-log net part "coming online")
                   (if-let [existing (get @vnodes part)]
                     (vnode/revive! existing)
                     (swap! vnodes assoc part
@@ -463,21 +463,21 @@
     (:offline :DROPPED [part m c]
               (try
                 (locking vnodes
-                  (info (:port net) part "dropped")
+                  (trace-log net part "dropped")
                   (when-let [vnode (get @vnodes part)]
                     (vnode/shutdown! vnode)
                     (swap! vnodes dissoc part)))
                 (catch Throwable t
-                  (fatal t (:port net) "dropping" part))))
+                  (fatal t (trace-log-prefix net) "dropping" part))))
 
     (:peer :offline [part m c]
            (try
              (locking vnodes
-               (info (:port net) part "going offline")
+               (trace-log net part "going offline")
                (when-let [v (get @vnodes part)]
                  (vnode/zombie! v)))
              (catch Throwable t
-               (fatal t (:port net) "taking" part "offline"))))))
+               (fatal t (trace-log-prefix net) "taking" part "offline"))))))
 
 (defn start-local-vnodes!
   "Spins up a local zombie vnode for any local data."
@@ -492,7 +492,7 @@
                                               :host (:host node)
                                               :port (:port node)
                                               :ext "level"}))
-                    (info (:port node) "spooling up zombie vnode" part)
+                    (trace-log node "spooling up zombie vnode" part)
                     (let [v (new-vnode node part)]
                       (vnode/zombie! v)
                       (swap! vnodes assoc part v))))))
@@ -564,7 +564,7 @@
   "Blocks until all partitions are known to exist on a peer, then returns node."
   [node]
   (while (empty? (all-partitions node))
-    (info (:port node) "waiting-for-partition-list")
+    (trace-log node "waiting-for-partition-list")
     (Thread/sleep 10))
 
   (while (->> node

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -208,13 +208,14 @@
 (defn count-tasks-local
   "Estimates the total number of tasks on the local node."
   [node msg]
-  {:partitions
-   (reduce (fn [counts [k vnode]]
-             (if (vnode/active? vnode)
-               (assoc counts k (vnode/count-tasks vnode))
-               counts))
-           {}
-           (vnodes node))})
+  (let [partition-counts (reduce (fn [counts [k vnode]]
+                                   (if (vnode/active? vnode)
+                                     (assoc counts k (vnode/count-tasks vnode))
+                                     counts))
+                                 {}
+                                 (vnodes node))]
+    (trace-log node "count-tasks-local:" partition-counts)
+    {:partitions partition-counts}))
 
 (defn cover
   "Returns a map of nodes to lists of partitions on that node, such that each

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -512,11 +512,11 @@
                                          (epoch vnode)
                                          ", claim coordinator aborting"))))
     
-    (if (<= maj successes)
-      task
-      (throw (RuntimeException. (str "needed " maj
-                                     " acks from followers, only received "
-                                     successes))))))))
+        (if (<= maj successes)
+          task
+          (throw (RuntimeException. (str "needed " maj
+                                         " acks from followers, only received "
+                                         successes))))))))
 
 (defn complete!
   "Completes the given task in the specified claim. Msg should contain:

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -27,7 +27,7 @@
   :partition
   :state"
   [opts]
-  (info "starting vnode" (net/id (:net opts)) (:partition opts))
+  (info (format "%s/%s:" (net/string-id (net/id (:net opts))) (:partition opts)) "starting vnode")
   {:partition (:partition opts)
    :net       (:net opts)
    :router    (:router opts)
@@ -118,6 +118,19 @@
   "How long do we have to wait before initiating an election, in ms?"
   10000)
 
+;; Logging
+
+(defn full-id
+  "Full ID for vnode"
+  [vnode]
+  (format "%s/%s" (net/string-id (net-id vnode)) (:partition vnode)))
+
+(defmacro trace-log
+  "Log a message with context"
+  [vnode & args]
+  `(let [vnode-id# (format "%s:" (full-id ~vnode))]
+     (info vnode-id# ~@args)))
+
 (defn suppress-election!
   [vnode msg]
   (when (= (:epoch msg) (epoch vnode))
@@ -143,8 +156,7 @@
                                  (dissoc state :updated)))))]
         (when (:updated state)
           (suppress-election! vnode msg)
-          (info (net-id vnode) (:partition vnode)
-                "assuming epoch" leader-epoch)
+          (trace-log vnode "assuming epoch" leader-epoch)
           state)))))
 
 (defn request-vote!
@@ -160,7 +172,7 @@
   "Forces a leader to step down."
   [vnode]
   (locking vnode
-    (info (net-id vnode) (:partition vnode) "demoted")
+    (trace-log vnode "demoted")
     (swap! (:state vnode) (fn [state]
                            (if (= :leader (:type state))
                              (assoc state :type :follower)
@@ -171,14 +183,14 @@
   its data to a leader."
   [vnode]
   (locking vnode
-    (info (net-id vnode) (:partition vnode) "now zombie")
+    (trace-log vnode "now zombie")
     (swap! (:state vnode) assoc :type :zombie)))
 
 (defn revive!
   "Converts dead or zombie vnodes into followers."
   [vnode]
   (locking vnode
-    (info (net-id vnode) (:partition vnode) "revived!")
+    (trace-log vnode "revived!")
     (swap! (:state vnode) (fn [state]
                             (if (#{:zombie :dead} (:type state))
                               (assoc state :type :follower)
@@ -280,14 +292,14 @@
   we inform all zombies which are not a part of our new cohort that it is safe
   to drop their claim set."
   [vnode]
-  (info (net-id vnode) (:partition vnode) "initiating election")
+  (trace-log vnode "initiating election")
   (locking vnode
     (when (active? vnode)
-      (info (net-id vnode) "node is active")
+      (trace-log vnode "this node is active")
 
       (when (< (+ @(:last-leader-msg-time vnode) election-timeout)
                (flake/linear-time))
-        (info (net-id vnode) "leader is outdated")
+        (trace-log vnode "current leader is outdated")
 
         ; First, compute the set of peers that will comprise the next epoch.
         (let [self       (net-id vnode)
@@ -308,7 +320,7 @@
           (if (<= epoch (:epoch old))
             ; We're outdated; fast-forward to the new epoch.
             (do
-              (info (net-id vnode) "Outdated epoch relative to ZK; aborting election")
+              (trace-log vnode "Outdated epoch relative to ZK; aborting election")
               (swap! (:state vnode) (fn [state]
                                       (if (<= (:epoch state) (:epoch old))
                                         (merge state {:epoch (:epoch old)
@@ -322,7 +334,7 @@
                   responses   (atom (list))
                   accepted?   (promise)
                   peers       (disj (set/union new-cohort old-cohort) self)]
-              (info (net-id vnode) :old old-cohort :new new-cohort)
+              (trace-log vnode "Issuing requests for election" :old old-cohort :new new-cohort)
               (doseq [node peers]
                 (net/req! (:net vnode) (list node) {:r 1}
                           {:type :request-vote
@@ -336,33 +348,32 @@
                               ; Cancel request; we saw a newer epoch from a peer.
                               (do
                                 (deliver accepted? false)
-                                (info (net-id vnode) (:partition vnode)
+                                (trace-log vnode
                                       "aborting candidacy due to newer epoch"))
                               ; Have we enough votes?
                               (if (sufficient-votes? vnode old-cohort new-cohort rs)
                                 (do
                                   (deliver accepted? true)
-                                  (info (net-id vnode) "Received enough votes:" rs))
+                                  (trace-log vnode "Received enough votes:" rs))
                                 (when (<= (count peers) (count rs))
                                   (deliver accepted? false)
-                                  (info (net-id vnode) "All votes in; giving up.")))))))
+                                  (trace-log vnode "All votes in; giving up.")))))))
 
               ; Await responses
               (if-not (deref accepted? 5000 false)
-                (info (net-id vnode) (:partition vnode)
-                      "election failed; not enough votes")
+                (trace-log vnode "election failed; not enough votes")
 
                 ; Sync from old cohort.
                 (if-not (sync-with-majority! vnode
                                              old-cohort
                                              skuld.aae/sync-from!)
-                  (info (net-id vnode) "Wasn't able to replicate from enough of old cohort; cannot become leader.")
+                  (trace-log vnode "Wasn't able to replicate from enough of old cohort; cannot become leader.")
 
                   ; Sync to new cohort.
                   (if-not (sync-with-majority! vnode
                                                new-cohort
                                                skuld.aae/sync-to!)
-                    (error (net-id vnode) "Wasn't able to replicate to enough of new cohort; cannot become leader.")
+                    (errorf "%s: Wasn't able to replicate to enough of new cohort; cannot become leader." (full-id vnode))
 
                     ; Update ZK with new cohort and epoch--but only if nobody else
                     ; got there first.
@@ -374,8 +385,7 @@
                                                          new-leader
                                                          current)))]
                       (if (not= new-leader set-leader)
-                        (info (net-id vnode) (:partition vnode)
-                              "election failed: another leader updated zk")
+                        (trace-log vnode "election failed: another leader updated zk")
 
                         ; Success!
                         (let [state (swap! (:state vnode)
@@ -386,8 +396,7 @@
                                                ; We voted for someone else in the
                                                ; meantime
                                                state)))]
-                          (info (net-id vnode) (:partition vnode)
-                                "election successful: cohort now" epoch new-cohort))))))))))))))
+                          (trace-log vnode "election successful: cohort now" epoch new-cohort))))))))))))))
 
 ;; Tasks
 

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -533,5 +533,6 @@
 (defn wipe!
   "Wipe a vnode's data clean."
   [vnode]
+  (trace-log vnode "wiping vnode")
   (db/wipe! (:db vnode))
   vnode)


### PR DESCRIPTION
This works to clean up a lot of logging around vnodes, nodes and the network.

It includes:
- Prepending the host, port and partition in front of all log messages in skuld.vnode
- Providing a netty client exception handler
