### PR TITLE
Prevent claims to follower vnodes

### DIFF
--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -282,7 +282,7 @@
   (let [task (when-let [id (:id (queue/poll! (:queue node)))]
                ; Find vnode for this task
                (let [vnode (vnode node (partition-name node id))]
-                 (if-not (or vnode (vnode/leader? vnode))
+                 (if (or (not vnode) (not (vnode/leader? vnode)))
                    :retry
 
                    ; Claim task from vnode

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -282,7 +282,7 @@
   (let [task (when-let [id (:id (queue/poll! (:queue node)))]
                ; Find vnode for this task
                (let [vnode (vnode node (partition-name node id))]
-                 (if-not vnode
+                 (if-not (or vnode (vnode/leader? vnode))
                    :retry
 
                    ; Claim task from vnode


### PR DESCRIPTION
If a vnode has recently lost its leadership, the node queue may have IDs that
are no longer relevant.

This adds a check to skip any task that belongs to a vnode where this node
isn't the leader.

This is intended to fix #73.
