### PR TITLE
Add a new leaders tasks to the queue

### DIFF
--- a/src/skuld/scanner.clj
+++ b/src/skuld/scanner.clj
@@ -11,11 +11,10 @@
 (defn scan!
   "Scans over all tasks in a vnode."
   [queue vnode]
-  (let [leader? (vnode/leader? vnode)]
+  (if (vnode/leader? vnode)
     (doseq [task (vnode/tasks vnode)]
       ; Ensure the task is in the queue if this vnode is a leader.
-      (when leader?
-        (queue/update! queue task)))))
+      (queue/update! queue task))))
 
 (defn service
   "Starts a new scanning service. Takes an atom wrapping a map of partitions to

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -17,6 +17,8 @@
 (in-ns 'skuld.aae)
 (clojure.core/declare sync-from!)
 (clojure.core/declare sync-to!)
+(in-ns 'skuld.scanner)
+(clojure.core/declare scan!)
 (in-ns 'skuld.vnode)
 
 (declare wipe!)
@@ -386,6 +388,7 @@
                                                ; We voted for someone else in the
                                                ; meantime
                                                state)))]
+                          (skuld.scanner/scan! (:queue vnode) vnode)
                           (info (net-id vnode) (:partition vnode)
                                 "election successful: cohort now" epoch new-cohort))))))))))))))
 


### PR DESCRIPTION
When a vnode becomes master, there is an up to 1 second delay before the tasks in that vnode are added back to the queue (1 second is the interval the scanner runs).

This makes the scanner run as soon as the election has completed to prevent this delay (I believe it is the cause of some of the random failures that happen in the tests).

A fundamental question related to this is: Is it acceptable for skuld to return a `nil` in response to a `get-task` when there are tasks available? Right now it seems that there are at least one (and possibly more) reasons why it could happen during topology changes.
