### PR TITLE
Use URL-safe base64 encoding for ids

### DIFF
--- a/src/skuld/http.clj
+++ b/src/skuld/http.clj
@@ -17,7 +17,7 @@
 (defn- encode-bytes
   "Encode a bytes to the json generator."
   [^Bytes b ^JsonGenerator jg]
-  (.writeString jg (-> ^Bytes b .bytes b64/encode String.)))
+  (.writeString jg (-> ^Bytes b .bytes b64/encode String. (.replaceAll "\\+" "-") (.replaceAll "/" "_"))))
 
 ;; Custom Cheshire encoder for the Bytes type
 (add-encoder Bytes encode-bytes)
@@ -62,7 +62,7 @@
 (defn- b64->id
   "Coerces a base64-encoded id into a Bytes type."
   [^String b64-id]
-  (-> b64-id .getBytes b64/decode Bytes.))
+  (-> b64-id (.replaceAll "-" "+") (.replaceAll "_" "/" ) .getBytes b64/decode Bytes.))
 
 (defn- parse-int
   "Safely coerces a string into an integer. If the conversion is impossible,


### PR DESCRIPTION
This prevents issues related to passing IDs in URL paths by making them
url-safe.

RFC4648 has details: http://tools.ietf.org/html/rfc4648#section-5

This is a better solution than #70.
