### PR TITLE
Update last-leader-msg-time on successful election

### DIFF
--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -396,6 +396,7 @@
                                                ; We voted for someone else in the
                                                ; meantime
                                                state)))]
+                          (swap! (:last-leader-msg-time vnode) max (flake/linear-time))
                           (trace-log vnode "election successful: cohort now" epoch new-cohort))))))))))))))
 
 ;; Tasks


### PR DESCRIPTION
If a vnode election is successful, update last-leader-msg-time to the current time.

In looking into #81 I noticed that the leader does not consider itself being elected as seeing a leader message. I believe this would make it think that it is expired every time.
