### PR TITLE
Ensure only valid claims can be completed

### DIFF
--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -356,7 +356,7 @@
         (vnode/complete! vnode msg)
         {:w 1}
         (catch IllegalStateException ex
-          {:error (format "Could not complete claim for {}: {}" (:task-id msg) (.getMessage ex))}))
+          {:error (format "Could not complete claim for %s: %s" (:task-id msg) (.getMessage ex))}))
       {:error (str "I don't have partition" part "for task" (:task-id msg))})))
 
 (defn complete!

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -352,8 +352,11 @@
   [node msg]
   (let [part (->> msg :task-id (partition-name node))]
     (if-let [vnode (vnode node part)] 
-      (do (vnode/complete! vnode msg)
-          {:w 1})
+      (try
+        (vnode/complete! vnode msg)
+        {:w 1}
+        (catch IllegalStateException ex
+          {:error (format "Could not complete claim for {}: {}" (:task-id msg) (.getMessage ex))}))
       {:error (str "I don't have partition" part "for task" (:task-id msg))})))
 
 (defn complete!

--- a/src/skuld/task.clj
+++ b/src/skuld/task.clj
@@ -86,7 +86,17 @@
   "Returns a copy of the task, but completed. Takes a claim index, and a time
   to mark the task as completed at."
   [task claim-idx t]
-  (assoc-in task [:claims claim-idx :completed] t))
+  (when-not task
+    (throw (IllegalStateException. "task is nil")))
+
+  (when (completed? task)
+    (throw (IllegalStateException. "task is already completed")))
+
+  (if-let [claim (nth (:claims task) claim-idx nil)]
+    (if (valid-claim? claim)
+      (assoc-in task [:claims claim-idx :completed] t)
+      (throw (IllegalStateException. "claim is not valid")))
+    (throw (IllegalStateException. "claim does not exist"))))
 
 (defn mergev
   "Merges several vectors together, taking the first non-nil value for each

--- a/test/skuld/claim_test.clj
+++ b/test/skuld/claim_test.clj
@@ -58,7 +58,7 @@
   (elect! *nodes*)
   (with-redefs [task/clock-skew-buffer 0]
     (let [id (client/enqueue! *client* {:data "sup"})]
-      (is (client/claim! *client* 1))
+      (is (client/claim! *client* 1000))
 
       ; Isn't completed
       (is (not (task/completed? (client/get-task *client* id))))


### PR DESCRIPTION
In investigating #87 I noticed that there was no validation that a claim existed and was valid when it was completed.

I have asked some questions in #90 to clarify what the intended behavior is, but I believe that it shouldn't be possible to complete a claim that is not currently valid.
