### PR TITLE
Send heartbeats from leaders to keep their leadership

### DIFF
--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -630,11 +630,11 @@
   (locking node
     (when-not (shutdown? node)
       (when-let [c (:clock-sync node)] (clock-sync/shutdown! c))
-      (when-let [aae (:aae node)]      (aae/shutdown! aae))
-      (when-let [net (:net node)]      (net/shutdown! net))
-      (when-let [p (:politics node)]   (politics/shutdown! p))
-      (when-let [c (:curator node)]    (curator/shutdown! c))
       (when-let [s (:scanner node)]    (scanner/shutdown! s))
+      (when-let [aae (:aae node)]      (aae/shutdown! aae))
+      (when-let [p (:politics node)]   (politics/shutdown! p))
+      (when-let [net (:net node)]      (net/shutdown! net))
+      (when-let [c (:curator node)]    (curator/shutdown! c))
       (when-let [h (:http node)]       (skuld.http/shutdown! h))
 
       (->> (select-keys node [:participant :controller])

--- a/src/skuld/node.clj
+++ b/src/skuld/node.clj
@@ -401,6 +401,15 @@
       {:error (str (net/id (:net node))
                            " has no vnode for " (:partition msg))})))
 
+(defn heartbeat!
+  "Handles a request for a heartbeat from a leader."
+  [node msg]
+  (if-let [vnode (vnode node (:partition msg))]
+    (vnode/heartbeat! vnode msg)
+    (do
+      {:error (str (net/id (:net node))
+                   " has no vnode for " (:partition msg))})))
+
 (defn handler
   "Returns a fn which handles messages for a node."
   [node]
@@ -424,6 +433,7 @@
        :wipe               wipe!
        :wipe-local         wipe-local!
        :request-vote       request-vote!
+       :heartbeat          heartbeat!
        (constantly {:error (str "unknown message type" (:type msg))}))
      node msg)))
 

--- a/src/skuld/politics.clj
+++ b/src/skuld/politics.clj
@@ -16,14 +16,16 @@
                  (pmap
                    (fn [vnode]
                      (try
-                       (Thread/sleep (rand-int 100))
-                       (vnode/elect! vnode)
+                       (Thread/sleep (rand-int 300))
+                       (if (vnode/leader? vnode)
+                         (vnode/broadcast-heartbeat! vnode)
+                         (vnode/elect! vnode))
                        (catch Throwable t
-                         (warn t "electing" (:partition vnode))))))
+                         (warn t "exception while electing" (:partition vnode))))))
                dorun))
           (catch Throwable t
-            (warn t "in election cycle")))
-        (when (deref running 10000 true)
+            (warn t "exception in election cycle")))
+        (when (deref running 1000 true)
           (recur))))
     running))
 

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -250,7 +250,8 @@
 (defn heartbeat!
   "Handles a request for a heartbeat from a leader."
   [vnode msg]
-  (suppress-election! vnode msg))
+  (suppress-election! vnode msg)
+  (accept-newer-epoch! vnode msg))
 
 (defn broadcast-heartbeat!
   "Send a heartbeat to all followers to retain leadership."
@@ -475,8 +476,8 @@
   ... and applies the given claim to our copy of that task. Returns an empty
   map if the claim is successful, or {:error ...} if the claim failed."
   [vnode {:keys [id i claim] :as msg}]
-  (accept-newer-epoch! vnode msg)
   (suppress-election! vnode msg)
+  (accept-newer-epoch! vnode msg)
   (try
     (locking vnode
       (assert (not (zombie? vnode)))

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -118,6 +118,13 @@
   "How long do we have to wait before initiating an election, in ms?"
   10000)
 
+(defn leader-alive?
+  "Is the current leader still alive?"
+  [vnode]
+  (> (+ @(:last-leader-msg-time vnode) election-timeout)
+     (flake/linear-time)))
+
+
 ;; Logging
 
 (defn full-id
@@ -233,14 +240,29 @@
                  remaining
                  ; Copy data from another node and repeat
                  (recur (if (try (sync-fn vnode node)
-                                 (catch RuntimeException e
-                                   (locking *out*
-                                     (error e "while synchronizing"
-                                         (:partition vnode) "with" node))
-                                   false))
+                              (catch RuntimeException e
+                                     (error e "while synchronizing" (:partition vnode) "with" node)
+                                     false))
                           (dec remaining)
                           remaining)
                         more))))))
+
+(defn heartbeat!
+  "Handles a request for a heartbeat from a leader."
+  [vnode msg]
+  (suppress-election! vnode msg))
+
+(defn broadcast-heartbeat!
+  "Send a heartbeat to all followers to retain leadership."
+  [vnode]
+  (if (leader? vnode)
+    (let [epoch (epoch vnode)
+          peers (peers vnode)]
+      (net/sync-req! (:net vnode) peers {:r (count peers)}
+                     {:type      :heartbeat
+                      :partition (:partition vnode)
+                      :leader    (net-id vnode)
+                      :epoch     epoch}))))
 
 (defn elect!
   "Attempt to become a primary. We need to ensure that:
@@ -292,112 +314,109 @@
   we inform all zombies which are not a part of our new cohort that it is safe
   to drop their claim set."
   [vnode]
-  (trace-log vnode "initiating election")
   (locking vnode
-    (when (active? vnode)
-      (trace-log vnode "this node is active")
+    (when (and
+            (active? vnode)
+            (not (leader? vnode))
+            (not (leader-alive? vnode))))
+    (trace-log vnode "elect: initiating election. current leader is not alive")
 
-      (when (< (+ @(:last-leader-msg-time vnode) election-timeout)
-               (flake/linear-time))
-        (trace-log vnode "current leader is outdated")
+    ; First, compute the set of peers that will comprise the next epoch.
+    (let [self       (net-id vnode)
+          new-cohort (set (peers vnode))
 
-        ; First, compute the set of peers that will comprise the next epoch.
-        (let [self       (net-id vnode)
-              new-cohort (set (peers vnode))
+          ; Increment the epoch and update the node set.
+          epoch (-> vnode
+                    :state
+                    (swap! (fn [state]
+                             (merge state {:epoch (inc (:epoch state))
+                                           :leader self
+                                           :type :candidate
+                                           :cohort new-cohort})))
+                    :epoch)
 
-              ; Increment the epoch and update the node set.
-              epoch (-> vnode
-                        :state
-                        (swap! (fn [state]
-                                 (merge state {:epoch (inc (:epoch state))
-                                               :leader self
-                                               :type :candidate
-                                               :cohort new-cohort})))
-                        :epoch)
+          ; Check ZK's last leader information
+          old (deref (zk-leader vnode))]
+      (if (<= epoch (:epoch old))
+        ; We're outdated; fast-forward to the new epoch.
+        (do
+          (trace-log vnode "elect: Outdated epoch relative to ZK; aborting election. Fast-forwarding from" epoch "to" (:epoch old))
+          (swap! (:state vnode) (fn [state]
+                                  (if (<= (:epoch state) (:epoch old))
+                                    (merge state {:epoch (:epoch old)
+                                                  :leader false
+                                                  :type :follower
+                                                  :cohort (:cohort old)})
+                                    state))))
 
-              ; Check ZK's last leader information
-              old (deref (zk-leader vnode))]
-          (if (<= epoch (:epoch old))
-            ; We're outdated; fast-forward to the new epoch.
-            (do
-              (trace-log vnode "Outdated epoch relative to ZK; aborting election")
-              (swap! (:state vnode) (fn [state]
-                                      (if (<= (:epoch state) (:epoch old))
-                                        (merge state {:epoch (:epoch old)
-                                                      :leader false
-                                                      :type :follower
-                                                      :cohort (:cohort old)})
-                                        state))))
+        ; Issue requests to all nodes in old and new cohorts
+        (let [old-cohort  (set (:cohort old))
+              responses   (atom (list))
+              accepted?   (promise)
+              peers       (disj (set/union new-cohort old-cohort) self)]
+          (trace-log vnode "elect: Issuing requests for election for" epoch "transitioning from" old-cohort "to" new-cohort)
+          (doseq [node peers]
+            (net/req! (:net vnode) (list node) {:r 1}
+                      {:type :request-vote
+                       :partition (:partition vnode)
+                       :leader self
+                       :cohort new-cohort
+                       :epoch epoch}
+                      [[r]]
+                      (let [rs (swap! responses conj r)]
+                        (if (accept-newer-epoch! vnode r)
+                          ; Cancel request; we saw a newer epoch from a peer.
+                          (do
+                            (deliver accepted? false)
+                            (trace-log vnode "elect: aborting candidacy due to newer epoch"))
+                          ; Have we enough votes?
+                          (if (sufficient-votes? vnode old-cohort new-cohort rs)
+                            (do
+                              (deliver accepted? true)
+                              (trace-log vnode "elect: Received enough votes:" rs))
+                            (when (<= (count peers) (count rs))
+                              (deliver accepted? false)
+                              (trace-log vnode "elect: all votes in; election was lost")))))))
 
-            ; Issue requests to all nodes in old and new cohorts
-            (let [old-cohort  (set (:cohort old))
-                  responses   (atom (list))
-                  accepted?   (promise)
-                  peers       (disj (set/union new-cohort old-cohort) self)]
-              (trace-log vnode "Issuing requests for election" :old old-cohort :new new-cohort)
-              (doseq [node peers]
-                (net/req! (:net vnode) (list node) {:r 1}
-                          {:type :request-vote
-                           :partition (:partition vnode)
-                           :leader self
-                           :cohort new-cohort
-                           :epoch epoch}
-                          [[r]]
-                          (let [rs (swap! responses conj r)]
-                            (if (accept-newer-epoch! vnode r)
-                              ; Cancel request; we saw a newer epoch from a peer.
-                              (do
-                                (deliver accepted? false)
-                                (trace-log vnode
-                                      "aborting candidacy due to newer epoch"))
-                              ; Have we enough votes?
-                              (if (sufficient-votes? vnode old-cohort new-cohort rs)
-                                (do
-                                  (deliver accepted? true)
-                                  (trace-log vnode "Received enough votes:" rs))
-                                (when (<= (count peers) (count rs))
-                                  (deliver accepted? false)
-                                  (trace-log vnode "All votes in; giving up.")))))))
+          ; Await responses
+          (if-not (deref accepted? 5000 false)
+            (trace-log vnode "elect: election failed; not enough votes")
 
-              ; Await responses
-              (if-not (deref accepted? 5000 false)
-                (trace-log vnode "election failed; not enough votes")
+            ; Sync from old cohort.
+            (if-not (sync-with-majority! vnode
+                                         old-cohort
+                                         skuld.aae/sync-from!)
+              (trace-log vnode "elect: Wasn't able to replicate from enough of old cohort; cannot become leader.")
 
-                ; Sync from old cohort.
-                (if-not (sync-with-majority! vnode
-                                             old-cohort
-                                             skuld.aae/sync-from!)
-                  (trace-log vnode "Wasn't able to replicate from enough of old cohort; cannot become leader.")
+              ; Sync to new cohort.
+              (if-not (sync-with-majority! vnode
+                                           new-cohort
+                                           skuld.aae/sync-to!)
+                (errorf "%s: elect: Wasn't able to replicate to enough of new cohort; cannot become leader." (full-id vnode))
 
-                  ; Sync to new cohort.
-                  (if-not (sync-with-majority! vnode
-                                               new-cohort
-                                               skuld.aae/sync-to!)
-                    (errorf "%s: Wasn't able to replicate to enough of new cohort; cannot become leader." (full-id vnode))
+                ; Update ZK with new cohort and epoch--but only if nobody else
+                ; got there first.
+                (let [new-leader {:epoch epoch
+                                  :cohort new-cohort}
+                      set-leader (curator/swap!! (zk-leader vnode)
+                                                 (fn [current]
+                                                   (if (= old current)
+                                                     new-leader
+                                                     current)))]
+                  (if (not= new-leader set-leader)
+                    (trace-log vnode "elect: election failed: another leader updated zk")
 
-                    ; Update ZK with new cohort and epoch--but only if nobody else
-                    ; got there first.
-                    (let [new-leader {:epoch epoch
-                                      :cohort new-cohort}
-                          set-leader (curator/swap!! (zk-leader vnode)
-                                                     (fn [current]
-                                                       (if (= old current)
-                                                         new-leader
-                                                         current)))]
-                      (if (not= new-leader set-leader)
-                        (trace-log vnode "election failed: another leader updated zk")
-
-                        ; Success!
-                        (let [state (swap! (:state vnode)
-                                           (fn [state]
-                                             (if (= epoch (:epoch state))
-                                               ; Still waiting for responses
-                                               (assoc state :type :leader)
-                                               ; We voted for someone else in the
-                                               ; meantime
-                                               state)))]
-                          (swap! (:last-leader-msg-time vnode) max (flake/linear-time))
-                          (trace-log vnode "election successful: cohort now" epoch new-cohort))))))))))))))
+                    ; Success!
+                    (let [state (swap! (:state vnode)
+                                       (fn [state]
+                                         (if (= epoch (:epoch state))
+                                           ; Still waiting for responses
+                                           (assoc state :type :leader)
+                                           ; We voted for someone else in the
+                                           ; meantime
+                                           state)))]
+                      (trace-log vnode "elect: election successful: epoch is" epoch "for cohort" new-cohort)
+                      (broadcast-heartbeat! vnode))))))))))))
 
 ;; Tasks
 

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -88,8 +88,7 @@
                         vals
                         (remove partition-available?))]
       (when-not (empty? unelected)
-        (locking *out*
-          (info (count unelected) "unelected partitions"))
+        (info (count unelected) "unelected partitions")
 ;          (debug (map (partial map (juxt (comp :port vnode/net-id)
 ;                                       :partition
 ;                                       vnode/state))

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -89,7 +89,7 @@
                         (remove partition-available?))]
       (when-not (empty? unelected)
         (locking *out*
-          (debug (count unelected) "unelected partitions"))
+          (info (count unelected) "unelected partitions"))
 ;          (debug (map (partial map (juxt (comp :port vnode/net-id)
 ;                                       :partition
 ;                                       vnode/state))


### PR DESCRIPTION
Based on conversations in #81, I read the Raft paper about leader election and found that there was a fundamental place where the design of election in skuld diverged from Raft.

In Raft, the leader sends regular heartbeat messages to ensure they continue to keep their leadership.
## Status

:station: This is a work in progress.
## What does this change do?
- Add a new `:heartbeat` handler that calls `vnode/suppress-election!` to continue to keep `:last-leader-msg-time` up-to-date
- Adds a `vnode/broadcast-heartbeat!` function that is called at the end of a successful election and is called by `skuld.politics` on a leader instead of calling `vnode/elect!`
- Reduces the time between `skuld.politics` loops from 10 seconds to 1 second to make heartbeats run faster and reduce the amount of time before re-election is run
- Only performs `vnode/elect!` if the vnode isn't a leader and if the election-timeout has passed since :last-leader-msg-time`was updated (this means the leader completely ignores the current value of`:last-leader-msg-time`)
## What's still broken?

Some tests appear to be broken, but I haven't yet identified if this is because of a problem with the new implementation or if it is just interacting poorly with some of the tests.

Many tests override `vnode/election-timeout` to `0` from `10000` which may be causing some new funny interaction.
