### PR TITLE
Merge claims with nil start and end

### DIFF
--- a/src/skuld/task.clj
+++ b/src/skuld/task.clj
@@ -92,7 +92,10 @@
 (defn merge-by
   "Merges times by merge-fn"
   [merge-fn & times]
-  (merge-fn (filter (comp not nil?) times)))
+  (let [valid-times (filter (comp not nil?) times)]
+    (if (empty? valid-times)
+      nil
+      (apply merge-fn valid-times))))
 
 (defn merge-claims
   "Merges a collection of vectors of claims together."

--- a/test/skuld/task_test.clj
+++ b/test/skuld/task_test.clj
@@ -5,17 +5,6 @@
   (:require skuld.flake-test
             [skuld.flake :as flake]))
 
-(deftest mergev-test
-  (are [a b] (= (apply mergev a) b)
-       [] []
-       [[]] []
-       [[1 2 3]] [1 2 3]
-       [nil [1 2 3]] [1 2 3]
-       [[4 5 6] [1 2 nil]] [1 2 6]
-       [[1] [nil 2]] [1 2]
-       [[nil 2] [1 nil 3]] [1 2 3]
-       [[nil 1] [nil 2] [nil 3]] [nil 3]
-       ))
 
 (deftest merge-claim-test
   (testing "empty"
@@ -56,7 +45,15 @@
     (let [t (task {:data :hi})]
       (is (= (merge (assoc t :claims [{:start 0 :end 1 :completed 100}])
                     (assoc t :claims [{:start 2 :end 4 :completed 50}]))
+             (assoc t :claims [{:start 0 :end 4 :completed 50}])))))
+
+  (testing "completed without start"
+    (let [t (task {:data :hi})]
+      (is (= (merge (assoc t :claims [{:start 0 :end 1 :completed 100}])
+                    (assoc t :claims [{:start 2 :end 4}])
+                    (assoc t :claims [{:completed 50}]))
              (assoc t :claims [{:start 0 :end 4 :completed 50}]))))))
+
 
 (deftest claim-test
   (let [t (claim (task {:data :hi}) 10)]


### PR DESCRIPTION
Because any vnode is able to mark a claim as completed, there will be cases where the claim index being completed doesn't exist on that vnode yet.

`task/merge-claims` must be able to merge a claim that has no `start` and `end`.

This fixes #87 and has been discussed in #90 and #91.
