### PR TITLE
Queue per vnode

### DIFF
--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -29,8 +29,8 @@
   :state"
   [opts]
   (info (format "%s/%s:" (net/string-id (net/id (:net opts))) (:partition opts)) "starting vnode")
-  (let [queue    (queue/queue)
-         vnode   {:partition (:partition opts)
+  (let [queue   (queue/queue)
+        vnode   {:partition (:partition opts)
                  :net       (:net opts)
                  :router    (:router opts)
                  :queue     queue

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -433,7 +433,7 @@
   "Estimates the number of enqueued tasks."
   [vnode]
   (if (leader? vnode)
-    (count (:queue node))
+    (count (:queue vnode))
     0))
 
 (defn count-tasks
@@ -503,7 +503,7 @@
                       dec)]
 
     (when-not (= :leader (:type state))
-      (throw (IllegalStateException. (format "can't initiate claim: not a leader. current vnode type: {}" (:type state)))))
+      (throw (IllegalStateException. (format "can't initiate claim: not a leader. current vnode type: %s" (:type state)))))
 
     ; Look for the next available task
     (when-let [task-id (:id (queue/poll! (:queue vnode)))]

--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -29,10 +29,11 @@
   :state"
   [opts]
   (info (format "%s/%s:" (net/string-id (net/id (:net opts))) (:partition opts)) "starting vnode")
-  (let [vnode   {:partition (:partition opts)
+  (let [queue    (queue/queue)
+         vnode   {:partition (:partition opts)
                  :net       (:net opts)
                  :router    (:router opts)
-                 :queue     (queue/queue)
+                 :queue     queue
                  :db        (level/open {:partition (:partition opts)
                                          :host      (:host (:net opts))
                                          :port      (:port (:net opts))})


### PR DESCRIPTION
Move the queue off of node and onto the vnode.

When attempting to claim a new task, randomly attempt to claim a task from all vnodes on the node.

Related: #75, #77, #80.
### Status

Not ready to merge.
