### PR TITLE
Ensure we aren't writing to a closed leveldb database

### DIFF
--- a/src/skuld/db/level.clj
+++ b/src/skuld/db/level.clj
@@ -53,10 +53,12 @@
         (swap! count-cache inc))))
 
   (close! [db]
-    (swap! running (fn [was]
-                     (when was
-                       (.close ^Closeable level)
-                       false))))
+    (locking db
+      (swap! running (fn [was]
+                       (when was
+                         (.close ^Closeable level)
+                         false)))))
+
   
   (wipe! [db]
     (locking db

--- a/test/skuld/zk_test.clj
+++ b/test/skuld/zk_test.clj
@@ -19,4 +19,5 @@
        (try
          ~@body
          (finally
+           (.stop zk#)
            (.close zk#))))))


### PR DESCRIPTION
I've been seeing more segfaults recently and I wanted to ensure that we aren't trying to use a leveldb handle after it's been closed.
