### PR TITLE
Handle server exceptions

### DIFF
--- a/src/skuld/vnode.clj
+++ b/src/skuld/vnode.clj
@@ -585,7 +585,6 @@
 (defn wipe!
   "Wipe a vnode's data clean."
   [vnode]
-  (trace-log vnode "wiping vnode")
   (db/wipe! (:db vnode))
   (.clear (:queue vnode))
   vnode)

--- a/test/skuld/leader_test.clj
+++ b/test/skuld/leader_test.clj
@@ -71,14 +71,14 @@
             (test-election-consistent vnodes)))
 
         ; Initiate randomized elections
-        (->> vnodes
-             (map #(future
-                     (dotimes [i (rand-int 10)]
-                       (with-redefs [vnode/election-timeout 0]
+        (with-redefs [vnode/election-timeout 0]
+          (->> vnodes
+               (map #(future
+                       (dotimes [i (rand-int 10)]
                          (vnode/elect! %))
-                       (Thread/sleep (rand-int 10)))))
-             (map deref)
-             doall)
+                         (Thread/sleep (rand-int 10))))
+               (map deref)
+               doall))
 
         (deliver running false)
         (test-election-consistent vnodes)))))

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -104,8 +104,7 @@
 ;                                       vnode/state))
 ;                    unelected)))
         (doseq [vnodes unelected]
-          (with-redefs [vnode/election-timeout 0]
-            (vnode/elect! (rand-nth vnodes))))
+          (vnode/elect! (rand-nth vnodes)))
         (Thread/sleep 100)
         (recur (remove partition-available? unelected)))))
 

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -64,18 +64,18 @@
   "Wipe and shutdown a seq of nodes."
   [nodes]
   (->> nodes
-    (pmap (fn wipe-and-shutdown [node]
-            (wipe-local! node nil)
-            (shutdown! node)))
-    dorun))
+       (pmap (fn wipe-and-shutdown [node]
+               (wipe-local! node nil)
+               (shutdown! node)))
+       dorun))
 
 (defn wipe-nodes!
   "Wipe a seq of nodes."
   [nodes]
-  (dorun
-    (pmap (fn wipe [node]
-            (wipe-local! node nil))
-          nodes)))
+  (->> nodes
+       (pmap (fn wipe [node]
+               (wipe-local! node nil)))
+       dorun))
 
 
 (defn partition-available?


### PR DESCRIPTION
Trying to clean up more stray exceptions that aren't handled internally.

I also noticed that we are re-using the client across tests, which could mean there are still requests outstanding when we've moved on to a newer test, so I wanted to rule that out by closing the connection after each test.
