### PR TITLE
Named queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ skuld.bin=> (count-tasks c)
 0
 
 ; We can enqueue a task with some payload
-skuld.bin=> (enqueue! c {:data "sup?"})
+skuld.bin=> (enqueue! c {:queue "general" :data "sup?"})
 #<Bytes 00000140d20fa086800000019dace3c8ab1f6f82>
 
 ; Now there's 1 task
@@ -274,7 +274,7 @@ skuld.bin=> (pprint (list-tasks c))
 nil
 
 ; And now we can claim a task for 10 seconds
-skuld.bin=> (def t (claim! c 10000))
+skuld.bin=> (def t (claim! c "general" 10000))
 #'skuld.bin/t
 skuld.bin=> (pprint t)
 {:data "sup?",
@@ -283,13 +283,13 @@ skuld.bin=> (pprint t)
 nil
 
 ; We can't claim any other tasks during this time
-skuld.bin=> (claim! c 10000)
+skuld.bin=> (claim! c "general" 10000)
 nil
 
 ; But if we wait long enough, Skuld will decide the claim has expired. Once a
 ; quorum of nodes agree that the claim is outdated, we can re-claim the same
 ; task:
-skuld.bin=> (Thread/sleep 60000) (def t2 (claim! c 10000))
+skuld.bin=> (Thread/sleep 60000) (def t2 (claim! c "general" 10000))
 nil
 #'skuld.bin/t2
 skuld.bin=> t2

--- a/src/skuld/client.clj
+++ b/src/skuld/client.clj
@@ -44,11 +44,12 @@
 
 (defn claim!
   "Claim a task for dt milliseconds. Returns a task."
-  ([client dt]
-   (claim! client {} dt))
-  ([client opts dt]
-   (:task (sync-req! client opts {:type :claim
-                                  :dt   dt}))))
+  ([client queue dt]
+   (claim! client {} queue dt))
+  ([client opts queue dt]
+   (:task (sync-req! client opts {:type  :claim
+                                  :queue queue
+                                  :dt    dt}))))
 
 (defn complete!
   "Complete a task with the given task ID and claim ID."
@@ -76,8 +77,9 @@
 
 (defn count-queue
   "Returns a count of how many tasks are claimable."
-  [client]
-  (:count (sync-req! client {} {:type :count-queue})))
+  [client queue]
+  (:count (sync-req! client {} {:type  :count-queue
+                                :queue queue})))
 
 (defn list-tasks
   "Returns a list of tasks."

--- a/src/skuld/db/level.clj
+++ b/src/skuld/db/level.clj
@@ -31,16 +31,18 @@
         (let [claimed (task/claim task dt)]
           (level/put level
                      (.bytes ^Bytes (:id task))
-                     (task/claim task dt))
+                     claimed)
           claimed))))
 
-  (claim-task! [db id i claim]
+  (claim-task! [db task-id i claim]
     (locking db
       (assert @running)
-      (->> (-> db
-               (get-task id)
-               (task/request-claim i claim))
-           (level/put level (.bytes ^Bytes id)))))
+      (when-let [task (get-task db task-id)]
+        (let [claimed (task/request-claim task i claim)]
+          (level/put level
+                     (.bytes ^Bytes (:id task))
+                     claimed)
+          claimed))))
 
   (merge-task! [db task]
     (locking db

--- a/src/skuld/http.clj
+++ b/src/skuld/http.clj
@@ -75,14 +75,18 @@
 (defn- count-queue
   "Like `node/count-queue`, but wrapped around an HTTP request."
   [node req]
-  (let [r (-> req :query-params :r parse-int)]
-    (GET req (node/count-queue node {:r r}))))
+  (let [r     (-> req :query-params :r parse-int)
+        queue (-> req :query-params :queue)]
+    (GET req (node/count-queue node {:r     r
+                                     :queue queue}))))
 
 (defn- claim!
   "Like `node/claim!`, but wrapped around an HTTP request."
   [node req]
-  (let [dt (-> req :body :dt)
-        ret (node/claim! node {:dt dt})]
+  (let [dt    (-> req :body :dt)
+        queue (-> req :body :queue)
+        ret (node/claim! node {:queue queue
+                               :dt    dt})]
     (POST req (dissoc ret :request-id))))
 
 (defn- complete!

--- a/src/skuld/queue.clj
+++ b/src/skuld/queue.clj
@@ -52,7 +52,7 @@
                                      (assoc queues queue-name (named-queue))
                                      queues)))
                           queue-name))
-          ^ConcurrentSkipListSet q (:queue named-queue)]
+          q ^ConcurrentSkipListSet (:queue named-queue)]
 
       ; Mark the last time the queue was used
       (swap! (:last-modified named-queue) max (flake/linear-time))

--- a/src/skuld/queue.clj
+++ b/src/skuld/queue.clj
@@ -41,7 +41,7 @@
   [queues task]
   (let [queue-name (:queue task)]
     (if-not queue-name
-      (throw (IllegalArgumentException. "Task did not specify a queue")))
+      (throw (IllegalArgumentException. (str "Task did not specify a queue: " task))))
 
     (let [named-queue (if-let [queue (get @queues queue-name)]
                         queue

--- a/src/skuld/queue.clj
+++ b/src/skuld/queue.clj
@@ -13,32 +13,65 @@
                                  ConcurrentSkipListSet))
   (:use [skuld.util :exclude [update!]]
         clojure.tools.logging)
-  (:require [skuld.task :as task]))
-
-(defprotocol Queue
-  (update! [queue task])
-  (poll!   [queue]))
+  (:require [skuld.task :as task]
+            [skuld.flake :as flake]))
 
 (defrecord Task [id priority]
   Comparable
   (compareTo [a b]
     (compare+ a b :priority :id)))
 
-(defn queue
-  "Creates a new queue."
+(defn queues
+  "Creates a new set of queues."
   []
-  (ConcurrentSkipListSet.))
+  (atom {}))
 
-(extend-type ConcurrentSkipListSet
-  Queue
-  (update! [q task]
-    (if (or (nil? task)
-            (task/claimed? task)
-            (task/completed? task))
-      (.remove q (Task. (:id task)
-                        (:priority task)))
-      (.add q (Task. (:id task)
-                     (:priority task)))))
+(defn named-queue
+  []
+  {:queue         (ConcurrentSkipListSet.)
+   :last-modified (atom (flake/linear-time))})
 
-  (poll! [q]
-    (.pollFirst q)))
+(defn touch-named-queue
+  [named-queue]
+  (swap! (:last-modified named-queue) max (flake/linear-time)))
+
+
+(defn update!
+  "Update a task in the queue"
+  [queues task]
+  (let [queue-name (:queue task)]
+    (if-not queue-name
+      (throw (IllegalArgumentException. "Task did not specify a queue")))
+
+    (let [named-queue (if-let [queue (get @queues queue-name)]
+                        queue
+                        (get
+                          (swap! queues
+                                 (fn [queues]
+                                   (if-not (get queues queue-name)
+                                     (assoc queues queue-name (named-queue))
+                                     queues)))
+                          queue-name))
+          ^ConcurrentSkipListSet q (:queue named-queue)]
+
+      ; Mark the last time the queue was used
+      (swap! (:last-modified named-queue) max (flake/linear-time))
+
+      (if (or (nil? task)
+              (task/claimed? task)
+              (task/completed? task))
+        (.remove q (Task. (:id task)
+                          (:priority task)))
+        (.add q (Task. (:id task)
+                       (:priority task)))))))
+
+(defn poll!
+  [queues queue-name]
+  (if-let [named-queue (get @queues queue-name)]
+    (.pollFirst ^ConcurrentSkipListSet (:queue named-queue))))
+
+(defn count-queue
+  [queues queue-name]
+  (if-let [named-queue (get @queues queue-name)]
+    (count (:queue named-queue))
+    0))

--- a/src/skuld/queue.clj
+++ b/src/skuld/queue.clj
@@ -1,14 +1,13 @@
 (ns skuld.queue
-  "A node service which actually provides queuing semantics. You know,
+  "A vnode service which actually provides queuing semantics. You know,
   ordering, priorities, etc.
   
   Our general strategy with this queue is to be approximately consistent. If
   claim fails, come back and get another task. If a task is missing from this
   queue, AAE will recover it when it does a scan over the DB.
   
-  There's one queue per node. That queue is a rough approximation of all tasks
-  which could be claimed on the local node--e.g. it contains only tasks for
-  which the local node has a leader vnode."
+  There's one set of queues per vnode. Each named queue is a rough approximation
+  of all tasks that could be claimed on that vnode."
   (:import (java.util.concurrent TimeUnit
                                  ConcurrentSkipListSet))
   (:use [skuld.util :exclude [update!]]

--- a/test/skuld/queue_test.clj
+++ b/test/skuld/queue_test.clj
@@ -3,28 +3,31 @@
         clojure.test)
   (:require [skuld.task :as task]))
 
+(skuld.flake/init!)
+
 (deftest enqueue-test
-  (let [q (queue)]
-    (is (zero? (count q)))
+  (let [q (queues)]
+    (is (zero? (count-queue q "one")))
 
-    (update! q {:id 0 :foo :bar})
-    (is (= 1 (count q)))
+    (update! q {:queue "one" :id 0 :foo :bar})
+    (is (= 1 (count-queue q "one")))
 
-    (update! q {:id 0 :bar :baz})
-    (is (= 1 (count q)))
+    (update! q {:queue "one" :id 0 :bar :baz})
+    (is (= 1 (count-queue q "one")))
 
-    (is (= (->Task 0 nil) (poll! q)))
-    (is (= nil (poll! q)))))
+    (is (= (->Task 0 nil) (poll! q "one")))
+    (is (= nil (poll! q "one")))))
 
 (deftest order-test
-  (let [q (queue)]
-    (update! q {:id 1 :priority 1})
-    (update! q {:id 3 :priority 0})
-    (update! q {:id 2 :priority 2})
-    (update! q {:id 0 :priority 2})
+  (let [q (queues)]
+    (update! q {:queue "two" :id 1 :priority 1})
+    (update! q {:queue "one" :id 1 :priority 1})
+    (update! q {:queue "one" :id 3 :priority 0})
+    (update! q {:queue "one" :id 2 :priority 2})
+    (update! q {:queue "one" :id 0 :priority 2})
 
     (is (= [3 1 0 2 nil]
-           (->> (partial poll! q)
+           (->> (partial poll! q "one")
                 repeatedly
                 (take 5)
                 (map :id))))))

--- a/test/skuld/stress_test.clj
+++ b/test/skuld/stress_test.clj
@@ -26,7 +26,7 @@
 
   (let [n 100
         ids (->> (repeatedly (fn []
-                               (client/enqueue! *client* {:w 3} {:data "sup"})))
+                               (client/enqueue! *client* {:w 3} {:queue "queue12" :data "sup"})))
                  (take n)
                  doall)]
 
@@ -35,7 +35,7 @@
     ; Claim all extant IDs
     (let [deadline (+ (flake/linear-time) 20000)
            claims  (loop [claims {}]
-                    (if-let [t (client/claim! *client* 100000)]
+                    (if-let [t (client/claim! *client* "queue12" 100000)]
                       (do
                         ; Make sure we never double-claim
                         (assert (not (get claims (:id t))))
@@ -65,10 +65,10 @@
   (elect! *nodes*)
   
   ; Enqueue something and claim it.
-  (let [id       (client/enqueue! *client* {:w 3} {:data "meow"})
+  (let [id       (client/enqueue! *client* {:w 3} {:queue "queue13" :data "meow"})
         deadline (+ (flake/linear-time) 20000)
         claim    (loop []
-                   (if-let [claim (client/claim! *client* 100000)]
+                   (if-let [claim (client/claim! *client* "queue13" 100000)]
                      claim
                      (when (< (flake/linear-time) deadline)
                        (Thread/sleep 500)
@@ -131,6 +131,6 @@
 
       (let [c (client/client [(select-keys (first alive) [:host :port])])]
         (try
-          (is (not (client/claim! c 1000)))
+          (is (not (client/claim! c "queue13" 1000)))
           (finally
             (client/shutdown! c)))))))


### PR DESCRIPTION
Introduced named queues as discussed in #8.
### Highlights
- Instead of having a queue per `vnode`, there is now a queue per named queue on each `vnode`
- The task hash passed to `enqueue` needs to include a `:queue` key
- The `claim` and `count-queue` calls now take a `queue` argument

Right now there is no garbage collection of named queues that are no longer used, so the overhead of a `ConcurrentSkipListSet` will be around until the process is restarted.

Fixes #8.
