### PR TITLE
Add HTTP endpoint /id for flake id's

### DIFF
--- a/src/skuld/http.clj
+++ b/src/skuld/http.clj
@@ -9,7 +9,8 @@
             [ring.adapter.jetty        :refer [run-jetty]]
             [ring.middleware.json      :refer [wrap-json-body]]
             [ring.util.codec           :refer [form-decode]]
-            [skuld.node                :as node])
+            [skuld.node                :as node]
+            [skuld.flake               :as flake])
   (:import [com.aphyr.skuld Bytes]
            [com.fasterxml.jackson.core JsonGenerator JsonParseException]
            [org.eclipse.jetty.server Server]))
@@ -138,6 +139,10 @@
       (GET req {:error "No such task"} not-found)
       (GET req (dissoc ret :responses)))))
 
+(defn- id [req]
+  "Returns a flake id"
+  (GET req {:id (Bytes. (flake/id))}))
+
 (defn- make-handler
   "Given a node, constructs the handler function. Returns a response map."
   [node]
@@ -150,6 +155,7 @@
       "/tasks/enqueue"      (enqueue! node req)
       "/tasks/list"         (list-tasks node req)
       "/tasks/:id"          :>> (fn [{:keys [id]}] (get-task node req id))
+      "/id"                 (id req)
       not-found)))
 
 ;; Lifted from `ring.middleware.params`

--- a/test/skuld/node_test.clj
+++ b/test/skuld/node_test.clj
@@ -243,7 +243,7 @@
   (let [n 10]
     (dotimes [i n]
       (client/enqueue! *client* {:w 3} {:queue "queue7" :data "sup"}))
-   
+
     ; List
     (let [tasks (client/list-tasks *client*)]
       (is (= n (count tasks)))
@@ -284,6 +284,15 @@
     (let [resp (http/post (str "http://127.0.0.1:13100/tasks/" id)
                          {:throw-exceptions false})]
       (is (= 405 (:status resp))))))
+
+(deftest get-id-http-test
+  (let [resp (http/get "http://127.0.0.1:13100/id"
+                       {:content-type :json
+                        :as           :json})
+        id (-> resp :body :id)]
+    (is (= 200 (:status resp)))
+    (is (string? id))
+    (is (= 28 (count id)))))
 
 (deftest enqueue-http-test
   (let [resp (http/post "http://127.0.0.1:13100/tasks/enqueue"


### PR DESCRIPTION
I wasn't sure whether to just return the bare id, possibly as a string, or whether to put it in a map. A map is more extensible but I'm not sure how extensible we need this endpoint to be.

Resolves #108
