### PR TITLE
Add --zookeeper option to node command.

### DIFF
--- a/src/skuld/bin.clj
+++ b/src/skuld/bin.clj
@@ -35,7 +35,9 @@
      :default 3 :parse-fn parse-int]])
 
 (def node-spec
-  [["-p" "--port" "Port"     :default "13000"     :parse-fn parse-int]
+  [["-z" "--zookeeper" "Zookeeper connection string"
+    :default "localhost:2181"]
+   ["-p" "--port" "Port"     :default "13000"     :parse-fn parse-int]
    ["-h" "--host" "Hostname" :default "127.0.0.1"]])
 
 ; Cluster configuration


### PR DESCRIPTION
Same as for admin commands, so a node can be started without a Zookeeper instance running on localhost.

(Perhaps I missed something, but this didn't seem to be possible via 'lein run start'.)
